### PR TITLE
FIX: Early return for next image path

### DIFF
--- a/pages/_middleware.js
+++ b/pages/_middleware.js
@@ -43,6 +43,11 @@ export const middleware = (request) => {
       return undefined;
     }
 
+    // Early return if this is an next image route
+    if (nextUrl.pathname.includes("/_next/image")) {
+      return undefined;
+    }
+
     // Early return if there is a cookie present and on default locale
     if (cookies.NEXT_LOCALE && nextUrl.locale === "default") {
       url.pathname = `/${cookies.NEXT_LOCALE}${nextUrl.pathname}`;


### PR DESCRIPTION
If you use the next/image, the middleware adds the country or locale in the route. With this PR, I fixed this bug with;

```tsx
if (nextUrl.pathname.includes("/_next/image")) {
  return undefined;
}
```